### PR TITLE
Fix formatting

### DIFF
--- a/05-values.yaml
+++ b/05-values.yaml
@@ -4,8 +4,7 @@ experimental:
   kubernetesGateway: 
     appLabelSelector: traefik
     certificates:
-      - 
-        group: "core"
+      - group: "core"
         kind: "Secret"
         name: "mysecret"
     enabled: true


### PR DESCRIPTION
Simple formatting fix to put the list on the same line as the hyphen that starts it.